### PR TITLE
Fix sCMOS scalar variance map handling

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -42,7 +42,16 @@ end
 # Helper to extract variance map from SMLMData.SCMOSCamera
 function extract_variance_map(camera::SMLMData.SCMOSCamera, ::Type{T}) where T
     # SMLMData uses 'readnoise' field (std dev), we need variance (readnoise²)
-    return T.(camera.readnoise .^ 2)
+    # Handle both scalar and matrix readnoise
+    variance = camera.readnoise .^ 2
+    if variance isa Real
+        # Scalar readnoise: expand to full sensor matrix
+        ny = length(camera.pixel_edges_y) - 1
+        nx = length(camera.pixel_edges_x) - 1
+        return fill(T(variance), ny, nx)
+    else
+        return T.(variance)
+    end
 end
 
 """


### PR DESCRIPTION
## Summary
- Fix bug where SCMOSCamera with scalar readnoise caused GPU failure
- `extract_variance_map` now expands scalar readnoise to full sensor matrix

## Problem
When `SCMOSCamera` is created with uniform (scalar) readnoise:
```julia
camera = SCMOSCamera(100, 100, 0.1, 5.0)  # scalar readnoise
```
The `extract_variance_map` function returned a scalar, causing `copyto!` to fail when allocating GPU arrays.

## Solution
Check if variance is scalar and expand to matrix using sensor dimensions from `pixel_edges_x/y`.

## Test plan
- [x] All 202 tests pass
- [x] Manual test with scalar readnoise camera works on GPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)