### PR TITLE
ci: bump GitHub Actions to current majors for Node.js 24 deadline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v3
+      - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,16 +26,16 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+      - uses: julia-actions/julia-processcoverage@v3
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
   docs:
@@ -44,8 +44,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
## Summary

GitHub is forcing all Actions to Node.js 24 on **2026-06-02** and removing Node.js 20 entirely on **2026-09-16**. Our previously pinned majors run on Node.js 16/20 and would break.

Bumps the action versions in `.github/workflows/CI.yml`:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v2` | `@v4` |
| `julia-actions/setup-julia` | `@v1` | `@v2` |
| `julia-actions/cache` | `@v1` | `@v2` |
| `julia-actions/julia-processcoverage` | `@v1` | `@v3` |
| `codecov/codecov-action` | `@v2` | `@v5` |

No other changes. `julia-actions/julia-buildpkg`, `julia-actions/julia-runtest`, and `julia-actions/julia-docdeploy` are still on their current `@v1` major. `TagBot.yml` (`JuliaRegistries/TagBot@v1`) and `CompatHelper.yml` did not need updates.

## Test plan

- [ ] CI test matrix passes on all Julia versions (1.10, 1, nightly)
- [ ] Documentation build job succeeds and deploys
- [ ] Codecov upload succeeds with v5 (token may need to be set if not already — codecov-action v4+ prefers `CODECOV_TOKEN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)